### PR TITLE
Add capdl loader application to camkes Kconfig

### DIFF
--- a/manifests/Kconfig
+++ b/manifests/Kconfig
@@ -45,6 +45,7 @@ menu "Libraries"
 endmenu
 
 menu "Applications"
+    source "apps/capdl-loader-experimental/Kconfig"
     source "apps/smaccmpilot/Kconfig"
 endmenu
 


### PR DESCRIPTION
The capdl loader bootstraps a camkes system at runtime. It is required to build a runnable image.
